### PR TITLE
Replace betting overlay with buttons

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
     "css.lint.unknownAtRules": "ignore",
-    "scss.lint.unknownAtRules": "ignore"
+    "scss.lint.unknownAtRules": "ignore",
+    "cSpell.words": [
+        "gamefield"
+    ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/node": "^16.18.14",
         "@types/react": "^18.0.28",
         "@types/react-dom": "^18.0.11",
+        "classnames": "^2.3.2",
         "lodash": "^4.17.21",
         "mobx": "^6.8.0",
         "mobx-react": "^7.6.0",
@@ -5821,6 +5822,11 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA=="
+    },
+    "node_modules/classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "node_modules/clean-css": {
       "version": "5.3.2",
@@ -21525,6 +21531,11 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA=="
+    },
+    "classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "clean-css": {
       "version": "5.3.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@types/node": "^16.18.14",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
+    "classnames": "^2.3.2",
     "lodash": "^4.17.21",
     "mobx": "^6.8.0",
     "mobx-react": "^7.6.0",

--- a/src/components/betting-chips/BettingChip.tsx
+++ b/src/components/betting-chips/BettingChip.tsx
@@ -5,10 +5,11 @@ import styles from "./BettingChip.module.scss";
 import { useMainStore } from "../../hooks/useMainStore";
 
 export type BettingChipsValues = 1 | 5 | 25 | 50 | 100;
+export type BetOnOptions = "player" | "tie" | "bank";
 
 export type BettingChipProps = {
   value: BettingChipsValues;
-  betOn: string;
+  betOn: BetOnOptions;
 };
 
 export const BettingChip = observer((props: BettingChipProps) => {
@@ -29,9 +30,6 @@ export const BettingChip = observer((props: BettingChipProps) => {
       default:
         break;
     }
-
-    // game.setCurrentBet(value);
-    // console.log(betOn);
   };
 
   return (

--- a/src/components/betting-chips/BettingChip.tsx
+++ b/src/components/betting-chips/BettingChip.tsx
@@ -8,14 +8,30 @@ export type BettingChipsValues = 1 | 5 | 25 | 50 | 100;
 
 export type BettingChipProps = {
   value: BettingChipsValues;
+  betOn: string;
 };
 
 export const BettingChip = observer((props: BettingChipProps) => {
-  const { value } = props;
+  const { value, betOn } = props;
   const { game } = useMainStore();
 
   const addToBet = () => {
-    game.setCurrentBet(value);
+    switch (betOn) {
+      case "player":
+        game.addToPlayerBet(value);
+        break;
+      case "tie":
+        game.addToTieBet(value);
+        break;
+      case "bank":
+        game.addToBankerBet(value);
+        break;
+      default:
+        break;
+    }
+
+    // game.setCurrentBet(value);
+    // console.log(betOn);
   };
 
   return (

--- a/src/components/betting-chips/BettingControls.tsx
+++ b/src/components/betting-chips/BettingControls.tsx
@@ -14,15 +14,10 @@ export const BettingControls = observer(() => {
     setBettingChoice(e.target.value);
   };
 
-  if (game.gameStage === GameStage.InitialBet) {
-    betweenRoundsReset();
-  }
-
   const handleDeal = () => {
-    // if (game.gameStage === GameStage.InitialBet) {
-    //   game.setGameStage(GameStage.InitialCards);
-    //   // betweenRoundsReset();
-    // }
+    if (game.gameStage === GameStage.InitialBet) {
+      game.setGameStage(GameStage.InitialCards);
+    }
     if (game.gameStage === GameStage.SecondBet) {
       game.setGameStage(GameStage.CheckForThirdCard);
     }

--- a/src/components/betting-chips/BettingControls.tsx
+++ b/src/components/betting-chips/BettingControls.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { observer } from "mobx-react";
 import { useMainStore } from "../../hooks/useMainStore";
 import { GameStage } from "../../stores/gameStore";
-import { BettingChip, BettingChipsValues } from "./BettingChip";
+import { BettingChip, BettingChipsValues, BetOnOptions } from "./BettingChip";
 
 const bettingChipValues: BettingChipsValues[] = [1, 5, 25, 50, 100];
 
@@ -26,7 +26,11 @@ export const BettingControls = observer(() => {
   return (
     <>
       {bettingChipValues.map((value) => (
-        <BettingChip key={value} value={value} betOn={bettingChoice} />
+        <BettingChip
+          key={value}
+          value={value}
+          betOn={bettingChoice as BetOnOptions}
+        />
       ))}
       <button type="button" onClick={handleDeal}>
         Deal

--- a/src/components/betting-chips/BettingControls.tsx
+++ b/src/components/betting-chips/BettingControls.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { observer } from "mobx-react";
+import { useMainStore } from "../../hooks/useMainStore";
+import { GameStage } from "../../stores/gameStore";
+import { BettingChip, BettingChipsValues } from "./BettingChip";
+
+const bettingChipValues: BettingChipsValues[] = [1, 5, 25, 50, 100];
+
+export const BettingControls = observer(() => {
+  const { game, betweenRoundsReset } = useMainStore();
+  const [bettingChoice, setBettingChoice] = React.useState("");
+
+  const onOptionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setBettingChoice(e.target.value);
+  };
+
+  if (game.gameStage === GameStage.InitialBet) {
+    betweenRoundsReset();
+  }
+
+  const handleDeal = () => {
+    // if (game.gameStage === GameStage.InitialBet) {
+    //   game.setGameStage(GameStage.InitialCards);
+    //   // betweenRoundsReset();
+    // }
+    if (game.gameStage === GameStage.SecondBet) {
+      game.setGameStage(GameStage.CheckForThirdCard);
+    }
+  };
+
+  return (
+    <>
+      {bettingChipValues.map((value) => (
+        <BettingChip key={value} value={value} betOn={bettingChoice} />
+      ))}
+      <button type="button" onClick={handleDeal}>
+        Deal
+      </button>
+      <fieldset>
+        <legend>What do you want to bet on?</legend>
+
+        <div>
+          <label htmlFor="player">
+            <input
+              type="radio"
+              id="player"
+              name="bettingChoice"
+              value="player"
+              onChange={onOptionChange}
+            />
+            Player
+          </label>
+        </div>
+
+        <div>
+          <label htmlFor="tie">
+            <input
+              type="radio"
+              id="tie"
+              name="bettingChoice"
+              value="tie"
+              onChange={onOptionChange}
+            />
+            Tie
+          </label>
+        </div>
+
+        <div>
+          <label htmlFor="bank">
+            <input
+              type="radio"
+              id="bank"
+              name="bettingChoice"
+              value="bank"
+              onChange={onOptionChange}
+            />
+            Bank
+          </label>
+        </div>
+      </fieldset>
+    </>
+  );
+});

--- a/src/components/betting-chips/BettingControls.tsx
+++ b/src/components/betting-chips/BettingControls.tsx
@@ -7,7 +7,7 @@ import { BettingChip, BettingChipsValues, BetOnOptions } from "./BettingChip";
 const bettingChipValues: BettingChipsValues[] = [1, 5, 25, 50, 100];
 
 export const BettingControls = observer(() => {
-  const { game, betweenRoundsReset } = useMainStore();
+  const { game } = useMainStore();
   const [bettingChoice, setBettingChoice] = React.useState("");
 
   const onOptionChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/cards/Card.scss
+++ b/src/components/cards/Card.scss
@@ -1,4 +1,4 @@
-.flip-container:hover .flipper,
+// .flip-container:hover .flipper,
 .flip-container.flip .flipper {
   transform: rotateY(180deg);
 }

--- a/src/components/cards/Card.tsx
+++ b/src/components/cards/Card.tsx
@@ -1,21 +1,18 @@
 import React from "react";
+import { observer } from "mobx-react";
 import { Card as CardType } from "../../types";
 import "./Card.scss";
+// import { useMainStore } from "../../hooks/useMainStore";
 
 export type CardProps = {
   card: CardType;
 };
-export const Card = ({ card }: CardProps): JSX.Element => {
-  const [flipCard, setFlipCard] = React.useState(false);
+export const Card = observer(({ card }: CardProps): JSX.Element => {
+  // const { game } = useMainStore();
   const cardCSS = `front${card.face}${card.suit}`;
 
-  const timerId = setTimeout(() => {
-    // card.flipped = true;
-    setFlipCard(true);
-  }, 500);
-
   return (
-    <div className={flipCard ? "flip-container flip" : "flip-container"}>
+    <div className={card.flipped ? "flip-container flip" : "flip-container"}>
       <div className="flipper">
         <div className="front">
           <div className={`${cardCSS} size`} />
@@ -24,4 +21,4 @@ export const Card = ({ card }: CardProps): JSX.Element => {
       </div>
     </div>
   );
-};
+});

--- a/src/components/cards/Card.tsx
+++ b/src/components/cards/Card.tsx
@@ -1,18 +1,17 @@
 import React from "react";
 import { observer } from "mobx-react";
-import { Card as CardType } from "../../types";
+import cn from "classnames";
 import "./Card.scss";
-// import { useMainStore } from "../../hooks/useMainStore";
+import { Card as CardType } from "../../types";
 
 export type CardProps = {
   card: CardType;
 };
 export const Card = observer(({ card }: CardProps): JSX.Element => {
-  // const { game } = useMainStore();
   const cardCSS = `front${card.face}${card.suit}`;
 
   return (
-    <div className={card.flipped ? "flip-container flip" : "flip-container"}>
+    <div className={cn("flip-container", { flip: card.flipped })}>
       <div className="flipper">
         <div className="front">
           <div className={`${cardCSS} size`} />

--- a/src/components/game-setup/GameSetup.tsx
+++ b/src/components/game-setup/GameSetup.tsx
@@ -17,8 +17,8 @@ export const GameSetup = observer(() => {
     <>
       <GameField />
       {game.gameStage === GameStage.Continue && <ContinueOverlay />}
-      {game.gameStage === GameStage.InitialBet && <BettingOverlay />}
-      {game.gameStage === GameStage.SecondBet && <BettingOverlay />}
+      {/* {game.gameStage === GameStage.InitialBet && <BettingOverlay />}
+      {game.gameStage === GameStage.SecondBet && <BettingOverlay />} */}
     </>
   );
 });

--- a/src/components/game/GameField.tsx
+++ b/src/components/game/GameField.tsx
@@ -4,9 +4,10 @@ import { useMainStore } from "../../hooks/useMainStore";
 
 import { Card } from "../cards/Card";
 import styles from "./GameField.module.scss";
-import { BettingChip, BettingChipsValues } from "../betting-chips/BettingChip";
+// import { BettingChip, BettingChipsValues } from "../betting-chips/BettingChip";
+import { BettingControls } from "../betting-chips/BettingControls";
 
-const bettingChipValues: BettingChipsValues[] = [1, 5, 25, 50, 100];
+// const bettingChipValues: BettingChipsValues[] = [1, 5, 25, 50, 100];
 
 export const GameField = observer(() => {
   const { game, player, baccarat } = useMainStore();
@@ -19,7 +20,13 @@ export const GameField = observer(() => {
         <br />
         Cash: {player.playerMoney}
         <br />
-        Current bet: {game.bet}
+        Bet on player: {game.playerBet}
+        <br />
+        Bet on tie: {game.tieBet}
+        <br />
+        Bet on banker: {game.bankerBet}
+        <br />
+        Current bet: {game.totalBet}
       </p>
       <p>Game round number: {game.gameRound}</p>
       <div className={styles.players}>
@@ -41,9 +48,10 @@ export const GameField = observer(() => {
           </div>
         </div>
       </div>
-      {bettingChipValues.map((value) => (
+      {/* {bettingChipValues.map((value) => (
         <BettingChip key={value} value={value} />
-      ))}
+      ))} */}
+      <BettingControls />
       <p>Winner: {game.winner}</p>
     </div>
   );

--- a/src/components/game/GameField.tsx
+++ b/src/components/game/GameField.tsx
@@ -4,16 +4,12 @@ import { useMainStore } from "../../hooks/useMainStore";
 
 import { Card } from "../cards/Card";
 import styles from "./GameField.module.scss";
-// import { BettingChip, BettingChipsValues } from "../betting-chips/BettingChip";
 import { BettingControls } from "../betting-chips/BettingControls";
 import { GameStage } from "../../stores/gameStore";
 import { CardSuit } from "../../types";
 
-// const bettingChipValues: BettingChipsValues[] = [1, 5, 25, 50, 100];
-
 export const GameField = observer(() => {
   const { game, player, baccarat } = useMainStore();
-  console.log("GAMESTAGE = ", game.gameStage);
 
   const fakeCard = {
     face: "fake",
@@ -26,7 +22,7 @@ export const GameField = observer(() => {
     <div className={styles.gamefield}>
       <h1>Playing Baccarat</h1>
       <p>
-        Playername: {player.playerName}
+        Player name: {player.playerName}
         <br />
         Cash: {player.playerMoney}
         <br />

--- a/src/components/game/GameField.tsx
+++ b/src/components/game/GameField.tsx
@@ -6,11 +6,21 @@ import { Card } from "../cards/Card";
 import styles from "./GameField.module.scss";
 // import { BettingChip, BettingChipsValues } from "../betting-chips/BettingChip";
 import { BettingControls } from "../betting-chips/BettingControls";
+import { GameStage } from "../../stores/gameStore";
+import { CardSuit } from "../../types";
 
 // const bettingChipValues: BettingChipsValues[] = [1, 5, 25, 50, 100];
 
 export const GameField = observer(() => {
   const { game, player, baccarat } = useMainStore();
+  console.log("GAMESTAGE = ", game.gameStage);
+
+  const fakeCard = {
+    face: "fake",
+    suit: CardSuit.Clover,
+    value: 0,
+    flipped: false
+  };
 
   return (
     <div className={styles.gamefield}>
@@ -26,15 +36,27 @@ export const GameField = observer(() => {
         <br />
         Bet on banker: {game.bankerBet}
         <br />
-        Current bet: {game.totalBet}
+        Total bet: {game.totalBet}
       </p>
       <p>Game round number: {game.gameRound}</p>
       <div className={styles.players}>
         <div className={styles.playerField}>
           {player.playerName}: {baccarat.playerPoints} <br />
           <div className={styles.cards}>
-            <Card card={baccarat.playerCards[0]} />
-            <Card card={baccarat.playerCards[1]} />
+            <Card
+              card={
+                game.gameStage === GameStage.InitialBet
+                  ? fakeCard
+                  : baccarat.playerCards[0]
+              }
+            />
+            <Card
+              card={
+                game.gameStage === GameStage.InitialBet
+                  ? fakeCard
+                  : baccarat.playerCards[1]
+              }
+            />
             {baccarat.playerCards[2] && <Card card={baccarat.playerCards[2]} />}
           </div>
         </div>
@@ -42,15 +64,25 @@ export const GameField = observer(() => {
           Banker: {baccarat.bankerPoints}
           <br />
           <div className={styles.cards}>
-            <Card card={baccarat.bankerCards[0]} />
-            <Card card={baccarat.bankerCards[1]} />
+            <Card
+              card={
+                game.gameStage === GameStage.InitialBet
+                  ? fakeCard
+                  : baccarat.bankerCards[0]
+              }
+            />
+            <Card
+              card={
+                game.gameStage === GameStage.InitialBet
+                  ? fakeCard
+                  : baccarat.bankerCards[1]
+              }
+            />
             {baccarat.bankerCards[2] && <Card card={baccarat.bankerCards[2]} />}
           </div>
         </div>
       </div>
-      {/* {bettingChipValues.map((value) => (
-        <BettingChip key={value} value={value} />
-      ))} */}
+      <br />
       <BettingControls />
       <p>Winner: {game.winner}</p>
     </div>

--- a/src/components/overlays/BettingOverlay.tsx
+++ b/src/components/overlays/BettingOverlay.tsx
@@ -15,11 +15,11 @@ export const BettingOverlay = observer(() => {
 
   const handlePlacedBet = () => {
     if (game.gameStage === GameStage.InitialBet) {
-      game.setNewBet(bet);
+      // game.setNewBet(bet);
       betweenRoundsReset();
     }
     if (game.gameStage === GameStage.SecondBet) {
-      game.setCurrentBet(bet);
+      // game.setCurrentBet(bet);
       game.setGameStage(GameStage.CheckForThirdCard);
     }
   };

--- a/src/components/overlays/ContinueOverlay.tsx
+++ b/src/components/overlays/ContinueOverlay.tsx
@@ -6,9 +6,10 @@ import { useMainStore } from "../../hooks/useMainStore";
 import { GameStage } from "../../stores/gameStore";
 
 export const ContinueOverlay = observer(() => {
-  const { game, baccarat, endGameReset } = useMainStore();
+  const { game, baccarat, endGameReset, betweenRoundsReset } = useMainStore();
 
   const continueGame = () => {
+    betweenRoundsReset();
     game.setGameStage(GameStage.InitialBet);
   };
 

--- a/src/components/start-screen/StartScreen.tsx
+++ b/src/components/start-screen/StartScreen.tsx
@@ -20,7 +20,7 @@ export const StartScreen = () => {
   const handleStartGame = () => {
     game.setGameStage(GameStage.InitialCards);
     player.setPlayerName(name);
-    game.setCurrentBet(bet);
+    // game.setCurrentBet(bet);
   };
 
   return (

--- a/src/components/start-screen/StartScreen.tsx
+++ b/src/components/start-screen/StartScreen.tsx
@@ -18,7 +18,9 @@ export const StartScreen = () => {
   };
 
   const handleStartGame = () => {
-    game.setGameStage(GameStage.InitialCards);
+    // game.setGameStage(GameStage.InitialCards);
+    game.setGameStage(GameStage.InitialBet);
+    console.log("SENDING TO INTIAL BET");
     player.setPlayerName(name);
     // game.setCurrentBet(bet);
   };

--- a/src/stores/baccaratStore.ts
+++ b/src/stores/baccaratStore.ts
@@ -9,8 +9,6 @@ export class BaccaratStore {
 
   bankerCards: Card[] = [];
 
-  flipCard = false;
-
   setCards() {
     this.cards = getShuffledShoe(6);
   }

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -15,7 +15,13 @@ export class GameStore {
 
   gameRound = 1;
 
-  bet = 0;
+  // bet = 0;
+
+  playerBet = 0;
+
+  tieBet = 0;
+
+  bankerBet = 0;
 
   winner = "";
 
@@ -23,17 +29,38 @@ export class GameStore {
     makeAutoObservable(this, {}, { autoBind: true });
   }
 
+  get totalBet() {
+    return this.playerBet + this.tieBet + this.bankerBet;
+  }
+
   setGameStage(gameStage: GameStage) {
     this.gameStage = gameStage;
   }
 
-  setCurrentBet(bet: number) {
-    this.bet += bet;
+  addToPlayerBet(bet: number) {
+    this.playerBet += bet;
   }
 
-  setNewBet(bet: number) {
-    this.bet = bet;
+  addToTieBet(bet: number) {
+    this.tieBet += bet;
   }
+
+  addToBankerBet(bet: number) {
+    this.bankerBet += bet;
+  }
+
+  resetBets() {
+    this.playerBet = 0;
+    this.tieBet = 0;
+    this.bankerBet = 0;
+  }
+  // setCurrentBet(bet: number) {
+  //   this.bet += bet;
+  // }
+
+  // setNewBet(bet: number) {
+  //   this.bet = bet;
+  // }
 
   setWinner(winner: string) {
     this.winner = winner;
@@ -50,7 +77,11 @@ export class GameStore {
   resetGame() {
     this.setGameStage(GameStage.Start);
     this.gameRound = 1;
-    this.bet = 0;
+    // this.bet = 0;
+    this.resetBets();
+    this.playerBet = 0;
+    this.tieBet = 0;
+    this.bankerBet = 0;
     this.resetWinner();
   }
 }

--- a/src/stores/mainStore.ts
+++ b/src/stores/mainStore.ts
@@ -147,7 +147,7 @@ export class MainStore {
                   // banker third card according to players rule
                   this.baccarat.giveBankerACard();
                   const timer = setTimeout(() => {
-                    this.baccarat.playerCards[2].flipped = true;
+                    this.baccarat.bankerCards[2].flipped = true;
                     clearTimeout(timer);
                   }, 500);
                 }

--- a/src/stores/mainStore.ts
+++ b/src/stores/mainStore.ts
@@ -13,6 +13,7 @@ import {
 import { PlayerStore } from "./playerStore";
 import { BaccaratStore } from "./baccaratStore";
 import { GameStage, GameStore } from "./gameStore";
+import { WinnerOptions } from "../types";
 
 // bet,
 // player + bank 2 cards each
@@ -53,8 +54,14 @@ export class MainStore {
       this.baccarat.bankerPoints
     );
     this.game.setWinner(winner);
-    if (winner === "player") {
-      this.player.addPlayerMoney(this.game.totalBet);
+    if (winner === WinnerOptions.Player) {
+      this.player.addPlayerMoney(this.game.playerBet);
+    }
+    if (winner === WinnerOptions.Tie) {
+      this.player.addPlayerMoney(this.game.tieBet * 5);
+    }
+    if (winner === WinnerOptions.Banker) {
+      this.player.addPlayerMoney(this.game.bankerBet * 0.95);
     }
   }
 

--- a/src/stores/mainStore.ts
+++ b/src/stores/mainStore.ts
@@ -39,6 +39,8 @@ export class MainStore {
 
   betweenRoundsReset() {
     this.game.setGameStage(GameStage.InitialCards);
+    // this.game.setGameStage(GameStage.InitialBet);
+    this.game.resetBets();
     this.baccarat.resetPlayerCards();
     this.baccarat.resetBankerCards();
     this.game.resetWinner();
@@ -52,7 +54,7 @@ export class MainStore {
     );
     this.game.setWinner(winner);
     if (winner === "player") {
-      this.player.addPlayerMoney(this.game.bet);
+      this.player.addPlayerMoney(this.game.totalBet);
     }
   }
 

--- a/src/stores/mainStore.ts
+++ b/src/stores/mainStore.ts
@@ -39,8 +39,8 @@ export class MainStore {
   }
 
   betweenRoundsReset() {
-    this.game.setGameStage(GameStage.InitialCards);
-    // this.game.setGameStage(GameStage.InitialBet);
+    // this.game.setGameStage(GameStage.InitialCards);
+    this.game.setGameStage(GameStage.InitialBet);
     this.game.resetBets();
     this.baccarat.resetPlayerCards();
     this.baccarat.resetBankerCards();
@@ -73,11 +73,30 @@ export class MainStore {
       () => {
         runInAction(() => {
           switch (this.game.gameStage) {
+            case GameStage.InitialBet:
+              // this.baccarat.givePlayerACard();
+              // this.baccarat.givePlayerACard();
+              // this.baccarat.giveBankerACard();
+              // this.baccarat.giveBankerACard();
+              break;
             case GameStage.InitialCards:
               this.baccarat.givePlayerACard();
               this.baccarat.givePlayerACard();
               this.baccarat.giveBankerACard();
               this.baccarat.giveBankerACard();
+              // FLIP CARDS
+              this.baccarat.playerCards.forEach((card) => {
+                // eslint-disable-next-line no-param-reassign
+                card.flipped = true;
+              });
+              this.baccarat.bankerCards.forEach((card) => {
+                // eslint-disable-next-line no-param-reassign
+                card.flipped = true;
+              });
+              // this.baccarat.givePlayerACard();
+              // this.baccarat.givePlayerACard();
+              // this.baccarat.giveBankerACard();
+              // this.baccarat.giveBankerACard();
               setTimeout(() => {
                 this.game.setGameStage(GameStage.SecondBet);
               }, 2000);
@@ -104,6 +123,10 @@ export class MainStore {
                 // player needs third card?
                 if (needThirdCardPlayerRule(this.baccarat.playerPoints)) {
                   this.baccarat.givePlayerACard();
+                  let timer = setTimeout(() => {
+                    this.baccarat.playerCards[2].flipped = true;
+                    clearTimeout(timer);
+                  }, 500);
                   if (
                     // banker according to banker rule
                     needThirdCardBankersRule(
@@ -112,6 +135,10 @@ export class MainStore {
                     )
                   ) {
                     this.baccarat.giveBankerACard();
+                    timer = setTimeout(() => {
+                      this.baccarat.bankerCards[2].flipped = true;
+                      clearTimeout(timer);
+                    }, 500);
                   }
                 } else if (
                   needThirdCardPlayerRule(this.baccarat.bankerPoints)
@@ -119,6 +146,10 @@ export class MainStore {
                   // player didn't get third card
                   // banker third card according to players rule
                   this.baccarat.giveBankerACard();
+                  const timer = setTimeout(() => {
+                    this.baccarat.playerCards[2].flipped = true;
+                    clearTimeout(timer);
+                  }, 500);
                 }
                 // check for winner
                 setTimeout(() => {

--- a/src/stores/mainStore.ts
+++ b/src/stores/mainStore.ts
@@ -123,8 +123,10 @@ export class MainStore {
                 // player needs third card?
                 if (needThirdCardPlayerRule(this.baccarat.playerPoints)) {
                   this.baccarat.givePlayerACard();
-                  let timer = setTimeout(() => {
-                    this.baccarat.playerCards[2].flipped = true;
+                  const timer = setTimeout(() => {
+                    if (this.baccarat.playerCards[2]) {
+                      this.baccarat.playerCards[2].flipped = true;
+                    }
                     clearTimeout(timer);
                   }, 500);
                   if (
@@ -135,9 +137,11 @@ export class MainStore {
                     )
                   ) {
                     this.baccarat.giveBankerACard();
-                    timer = setTimeout(() => {
-                      this.baccarat.bankerCards[2].flipped = true;
-                      clearTimeout(timer);
+                    const timer2 = setTimeout(() => {
+                      if (this.baccarat.bankerCards[2]) {
+                        this.baccarat.bankerCards[2].flipped = true;
+                      }
+                      clearTimeout(timer2);
                     }, 500);
                   }
                 } else if (
@@ -147,7 +151,9 @@ export class MainStore {
                   // banker third card according to players rule
                   this.baccarat.giveBankerACard();
                   const timer = setTimeout(() => {
-                    this.baccarat.bankerCards[2].flipped = true;
+                    if (this.baccarat.bankerCards[2]) {
+                      this.baccarat.bankerCards[2].flipped = true;
+                    }
                     clearTimeout(timer);
                   }, 500);
                 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,9 @@
+export enum WinnerOptions {
+  Player = "Player",
+  Tie = "Tie",
+  Banker = "Bank"
+}
+
 export enum CardSuit {
   Clover = "C",
   Diamond = "D",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import { shuffle } from "lodash";
-import { Card, suits, cardFaces } from "./types";
+import { Card, suits, cardFaces, WinnerOptions } from "./types";
 
 export const createCardDeck48Cards = (): Card[] => {
   const cardDeck: Card[] = [];
@@ -40,10 +40,10 @@ export const getPoints = (cards: Card[]): number => {
 export const checkWinner = (
   playerPoints: number,
   bankPoints: number
-): string => {
-  if (playerPoints === bankPoints) return "tie";
-  if (playerPoints > bankPoints) return "player";
-  return "bank";
+): WinnerOptions => {
+  if (playerPoints === bankPoints) return WinnerOptions.Tie;
+  if (playerPoints > bankPoints) return WinnerOptions.Player;
+  return WinnerOptions.Banker;
 };
 
 export const needThirdCardPlayerRule = (points: number): boolean => {


### PR DESCRIPTION
BettingOverlay is replaced by betting chips.
Added basic functionality for placing bets on: Player, Tie, Bank.
Amount of won money is calculated based on where the bet was placed.
Adjusted game logic to work with the betting chips.
Using the flipped-flag on the card for flipping after the deal-button is clicked.